### PR TITLE
Creating New Gradle Builds – explicitly state which file needs to be modified

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -142,7 +142,7 @@ Gradle comes with a library of tasks that you can configure in your own projects
 
 . Create a directory called `src`.
 . Add a file called `myfile.txt` in the `src` directory. The contents are arbitrary (it can even be empty), but for convenience add the single line `Hello, World!` to it.
-. Define a task called `copy` of type `Copy` (note the capital letter) that copies the `src` directory to a new directory called `dest`. (You don't have to create the `dest` directory -- the task will do it for you.) The syntax is:
+. In your `build.gradle` file, define a task called `copy` of type `Copy` (note the capital letter) that copies the `src` directory to a new directory called `dest`. (You don't have to create the `dest` directory -- the task will do it for you.) The syntax is:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Explicitly state in which file the task must be defined, since it is unclear in the present context.  Everywhere else in the page, it is stated as "your `build.gradle`".