### PR TITLE
Change 'basic' plugin to 'base' plugin in text

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -202,7 +202,7 @@ $ ./gradlew zip
 include::{samplesoutputdir}/gradle-zip.txt[]
 ----
 
-Run the `tasks` command again to see the tasks added by the `basic` plugin.
+Run the `tasks` command again to see the tasks added by the `base` plugin.
 
 [listing]
 ----


### PR DESCRIPTION
I believe this was a simple typo - should be `base` rather than `basic`.